### PR TITLE
Added data about Kickstart

### DIFF
--- a/data/tools/kickstart.json
+++ b/data/tools/kickstart.json
@@ -1,0 +1,13 @@
+[
+  {
+    "slug": "kickstart",
+    "name": "Kickstart",
+    "description": "A Bash provisioning tool with no extra dependency on the target host or the client. It comes with a set of helper functions that abstract some diferences like package management and brings indepotency to some commands.",
+    "tags": [
+      "linux",
+      "open-source",
+      "provisioning"
+    ],
+    "url": "https://github.com/bltavares/kickstart"
+  }
+]


### PR DESCRIPTION
Kickstart is a Bash only provisioning tool, with no extra dependencies on the client or target.

The idea is to use bash scripts to provision machines over ssh, with no client installation on the target. It provides some abstractions and functions that help you structure and write more readable bash scripts. For an example project, check kickstart-baseline.
