### PR TITLE
Added 'Documentation' topic with 2 tools

### DIFF
--- a/data/tools/google-docs.json
+++ b/data/tools/google-docs.json
@@ -2,9 +2,11 @@
   {
     "slug": "google-docs",
     "name": "Google Docs",
-    "description": "A powerful document creation platform. Supports features such as: realtime collaboration, offline document editing, inline document comments, search and full differential changelog.",
+    "description": "A powerful document creation platform. Supports features such as: realtime collaboration, offline document editing, inline document comments, search and full differential changelog. Free for personal use, costs for commercial",
     "tags": [
       "documentation",
+      "free",
+      "commercial"
     ],
     "url": "http://www.google.com/docs/about/"
   }

--- a/data/tools/google-docs.json
+++ b/data/tools/google-docs.json
@@ -1,0 +1,11 @@
+[
+  {
+    "slug": "google-docs",
+    "name": "Google Docs",
+    "description": "A powerful document creation platform. Supports features such as: realtime collaboration, offline document editing, inline document comments, search and full differential changelog.",
+    "tags": [
+      "documentation",
+    ],
+    "url": "http://www.google.com/docs/about/"
+  }
+]

--- a/data/tools/hackpad.json
+++ b/data/tools/hackpad.json
@@ -3,9 +3,11 @@
   {
     "slug": "hackpad",
     "name": "Hackpad",
-    "description": "A lightweight, markdown based, document creation platform packed full of features such as: realtime collaboration, offline document reading (via dropbox), in documment comments, search / tagging and full diff'd changelog.",
+    "description": "A lightweight, markdown based, document creation platform packed full of features such as: realtime collaboration, offline document reading (via dropbox), in documment comments, search / tagging and full diff'd changelog. Private workspaces free for the first 5 users, Public workspaces always free.",
     "tags": [
       "documentation",
+      "free",
+      "commercial"
     ],
     "url": "http://www.hackpad.com/"
   }

--- a/data/tools/hackpad.json
+++ b/data/tools/hackpad.json
@@ -1,0 +1,12 @@
+
+[
+  {
+    "slug": "hackpad",
+    "name": "Hackpad",
+    "description": "A lightweight, markdown based, document creation platform packed full of features such as: realtime collaboration, offline document reading (via dropbox), in documment comments, search / tagging and full diff'd changelog.",
+    "tags": [
+      "documentation",
+    ],
+    "url": "http://www.hackpad.com/"
+  }
+]

--- a/data/topics.json
+++ b/data/topics.json
@@ -34,4 +34,8 @@
   "name": "Logging & Monitoring",
   "slug": "monitoring",
   "include_tags": [ "monitoring" ]
+}, {
+  "name": "Documentation",
+  "slug": "documentation",
+  "include_tags": ["documentation", "cms"]
 }]


### PR DESCRIPTION
I have been researching documentation platforms for training and knowledge transfer at my current company. I have added Hackpad and GoogleDocs so far.

Might be worth introducing a few new tags, possibly 'web' (or something similar to denote a web platform), this would be useful for describing any SaaS, PaaS and IaaS services. Also 'api' to denote a tool that exposes an API to further integrate with it (both Hackpad and GoogleDocs have one).
