### PR TITLE
Add chef to configuration management tools

### DIFF
--- a/data/tools/chef.json
+++ b/data/tools/chef.json
@@ -1,0 +1,15 @@
+[
+  {
+    "slug": "chef",
+    "name": "Chef",
+    "description": "Configuration management tool which uses a pure-Ruby, domain-specific language (DSL) for writing system configuration recipes. Supports Linux, UNIX, Windows, and AIX as first-class citizens for management.",
+    "tags": [
+      "linux",
+      "windows",
+      "open-source",
+      "provisioning",
+      "configuration-management"
+    ],
+    "url": "http://www.getchef.com"
+  }
+]


### PR DESCRIPTION
Added in Chef; could add some additional details at some point. Also tagged it as "configuration-management" as that category seems to be lacking.
