### PR TITLE
Reorder config mgmt in topics

### DIFF
--- a/data/topics.json
+++ b/data/topics.json
@@ -2,10 +2,6 @@
   "name": "Source Code Management",
   "slug": "scm",
   "include_tags": [ "scm", "vcs" ]
-}, { 
-  "name": "Configuration Management",
-  "slug": "config-management",
-  "include_tags": [ "cm", "config", "configuration", "config-management" ]
 }, {
   "name": "Continuous Integration & Delivery",
   "slug": "ci",
@@ -22,6 +18,10 @@
   "name": "Cloud & PaaS Environments",
   "slug": "cloud-paas",
   "include_tags": [ "cloud-paas" ]
+}, {
+  "name": "Configuration Management",
+  "slug": "config-management",
+  "include_tags": [ "cm", "config", "configuration", "config-management" ]
 }, {
   "name": "Provisioning",
   "slug": "provisioning",


### PR DESCRIPTION
Originally topics were structured as: Develop > Integrate > Deploy > Post-deploy. Hence the topics went like SCM > CI/CD > Packaging > Virt/Cloud > Provisioning > ... > Process Mgmt > Logging & Monitoring.

Reordered Config Mgmt to be a closer fit to the order. Would like people to have a look and see if this is ok...
