### PR TITLE
Adding Landscape.io continuous Python code metrics

### DIFF
--- a/data/tools/landscape.json
+++ b/data/tools/landscape.json
@@ -1,0 +1,15 @@
+[
+  {
+    "slug": "landscape",
+    "name": "Landscape.io",
+    "description": "Landscape.io provides hosted continuous static analysis for Python. After every commit, code is inspected to find errors, code smells and find style guide violations. It integrates with GitHub, and provides trends and comparisons between commits and branches.",
+    "tags": [
+      "free",
+      "commercial",
+      "ci",
+      "scm",
+      "python"
+    ],
+    "url": "http://landscape.io"
+  }
+]

--- a/data/tools/landscape.json
+++ b/data/tools/landscape.json
@@ -10,6 +10,6 @@
       "scm",
       "python"
     ],
-    "url": "http://landscape.io"
+    "url": "https://landscape.io"
   }
 ]


### PR DESCRIPTION
I don't see a way to add a 'tools' label, sorry!

Also, I wasn't entirely sure if "scm" and "ci" tags apply to services like Landscape or Coveralls (PR coming soon).
