### PR TITLE
Updated cft.json

### DIFF
--- a/data/tools/cft.json
+++ b/data/tools/cft.json
@@ -10,6 +10,6 @@
       "provisioning",
       "orchestration"
     ],
-    "url": "http://cft.et.redhat.com"
+    "url": "https://gitorious.org/cft/cft"
   }
 ]


### PR DESCRIPTION
Non-working URL. This appears to be the canonical source now.
