### PR TITLE
add r10k deployment tool

### DIFF
--- a/data/tools/r10k.json
+++ b/data/tools/r10k.json
@@ -1,0 +1,16 @@
+[
+  {
+    "slug": "r10k",
+    "name": "r10k",
+    "description": "r10k provides a general purpose toolset for deploying Puppet environments and modules. It implements the Puppetfile format and provides a native implementation of Puppet dynamic environments.",
+    "url": "https://github.com/adrienthebo/r10k",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "open-source",
+      "free",
+      "scm"
+    ]
+  }
+]


### PR DESCRIPTION
r10k provides a general purpose toolset for deploying Puppet environments and modules. It implements the Puppetfile format and provides a native implementation of Puppet dynamic environments.
