### PR TITLE
Update Vagrant, use Node from nodesource, and other changes

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,13 @@ and frameworks.
 
 Refer to [CONTRIBUTING.md](https://github.com/devopsbookmarks/devopsbookmarks.com/blob/master/CONTRIBUTING.md)
 
+## Development
+
+* Make sure you have VirtualBox and Vagrant installed
+* Clone this repository
+* Run `vagrant up` to provision the VM
+* Run `vagrant ssh -c /vagrant/script/server` to start the server
+
 ## Inspiration
 
 * http://www.unheap.com/

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -3,45 +3,30 @@ VAGRANTFILE_API_VERSION = "2"
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   config.vm.box = "ubuntu/trusty64"
+  config.vm.network "forwarded_port", guest: 3000, host: 3000
+
+  if Vagrant.has_plugin?('vagrant-cachier')
+    config.cache.scope = :box
+  else
+    puts "Run `vagrant plugin install vagrant-cachier` to reduce caffeine intake when provisioning"
+  end
 
   config.vm.provision :shell, privileged: true, inline: <<-SCRIPT
-    if [ -z `which node` ]; then
-      echo "Installing necessary packages..."
-      apt-get update
-      apt-get install nodejs npm git -y
-      npm install -g grunt-cli
-      ln -s /usr/bin/nodejs /usr/bin/node
-     fi;
-  SCRIPT
-
-  config.vm.provision :shell, privileged: true, inline: <<-SCRIPT
-    cd /vagrant
-    mkdir -p log
-
+    echo "Installing necessary packages..."
+    curl -sSL https://deb.nodesource.com/setup | sudo bash -
+    apt-get install -y build-essential git nodejs
+    npm install -g grunt-cli
 
     echo 'Fix potential git problem with Bower set up and connecting to github'
     git config --global url."https://".insteadOf git://
-
-    # piping output because express crashes when stdout/stderr is disconnected
-    killall node
-    nohup script/server > log/express.log 2>&1 &
-
-    echo 'Waiting for server to start...'
-    while true; do
-      lsof -i :3000 > /dev/null
-      if [[ $? == 0 ]]; then
-        break
-      fi;
-    done
   SCRIPT
 
-  # Create a forwarded port mapping which allows access to a specific port
-  # within the machine from a port on the host machine. In the example below,
-  # accessing "localhost:8080" will access port 80 on the guest machine.
-  config.vm.network "forwarded_port", guest: 3000, host: 3000
+  config.vm.provision :shell, privileged: false, inline: <<-SCRIPT
+    cd /vagrant
+    npm install
 
-  # If true, then any SSH connections made will enable agent forwarding.
-  # Default value: false
-  # config.ssh.forward_agent = true
-  #
+    echo "Provisioning complete, run:"
+    echo "  vagrant ssh -c /vagrant/script/server"
+    echo "to start the server"
+  SCRIPT
 end

--- a/script/server
+++ b/script/server
@@ -2,5 +2,6 @@
 
 set -xe
 
-npm install --no-bin-links
+cd `dirname ${0%/*}`
+npm install
 grunt dev


### PR DESCRIPTION
I was facing difficulties troubleshooting errors when provisioning with Vagrant. Since `script/server` ran headlessly, I couldn't see any logs or errors with bower and other packages. Also when running the app, making changes to files sometimes breaks the app, but I'm not able to see any logs :( End of the day, without SSHing into the box and tailing the logs, doing meaningful development was difficult. So I propose a simpler method:

  * `vagrant up` will install everything in the foreground, including doing a `npm install` to install dependencies
  * It will print at the end `Please run vagrant ssh -c /vagrant/script/server` *(single command)*
  * Running `vagrant ssh -c /vagrant/script/server` will run the server in the foreground directly, no need to `ssh`, `cd` and then run stuff

I propose this since having STDOUT of the server which prints logs and errors as I keep changing files seems to be essential for development. Without that I don't get any feedback loop, and sometimes changing a file simply crashes node and I have no clue what went wrong.

Also I added a few more in the Vagrantfile:

* Support `vagrant-cachier` only if present
* Install latest nodejs from nodesource instead of outdated distro package
