### PR TITLE
adding: as3shebang - run ActionScript 3.0 shell scripts

### DIFF
--- a/data/tools/as3shebang.json
+++ b/data/tools/as3shebang.json
@@ -1,0 +1,16 @@
+[
+  {
+    "slug": "as3shebang",
+    "name": "AS3shebang",
+    "description": "Run ActionScript 3.0 shell scripts",
+    "url": "https://github.com/Corsaair/as3shebang",
+    "tags": [
+      "linux",
+      "osx",
+      "open-source",
+      "config",
+      "shell",
+      "actionscript"
+    ]
+  }
+]


### PR DESCRIPTION
as3shebang embed the RedTamarin runtime and allow to run ActionScript 3.0 shell scripts
as a sysadmin/devops I use it to develop more complex scripts for configuration and automation,
maybe other could find it useful.

see for reference:

  https://github.com/Corsaair/redtamarin
  https://github.com/adobe-flash/avmplus

  http://redtamarin.com/
  http://docs.redtamarin.com/
  
  few examples
  https://gist.github.com/zwetan
