### PR TITLE
Add gogs

### DIFF
--- a/data/tools/gogs.json
+++ b/data/tools/gogs.json
@@ -1,0 +1,15 @@
+[
+  {
+    "slug": "Gogs",
+    "name": "Gogs",
+    "description": "A self-hosted Git service written in Go. Gogs(Go Git Service) is a painless self-hosted Git Service written in Go. The goal of this project is to make the easiest, fastest and most painless way to set up a self-hosted Git service. With Go, this can be done in independent binary distribution across ALL platforms that Go supports, including Linux, Mac OS X, and Windows.",
+    "tags": [
+      "linux",
+      "open-source",
+      "git",
+      "go",
+      "scm"
+    ],
+    "url": "http://gogs.io/"
+  }
+]


### PR DESCRIPTION
Add Gogs, self-hosted Git Service written in Go