### PR TITLE
Add StackStorm

### DIFF
--- a/data/tools/stackstorm.json
+++ b/data/tools/stackstorm.json
@@ -1,0 +1,23 @@
+[
+  {
+    "slug": "stackstorm",
+    "name": "StackStorm",
+    "description": "A platform for event-driven automation. StackStorm allows you to integrate and automate across services and tools. It ties together your existing infrastructure and application environment so you can more easily automate that environment -- with a particular focus on taking actions in response to events.",
+    "url": "http://www.stackstorm.com",
+    "tags": [
+      "automation",
+      "continous-delivery",
+      "provisioning",
+      "cloud",
+      "orchestration",
+      "config-management",
+      "orchestration",
+      "python",
+
+      "linux",
+
+      "open-source",
+      "apache2"
+    ]
+  }
+]


### PR DESCRIPTION
This pull request adds a new entry for StackStorm (http://www.stackstorm.com, https://github.com/stackstorm/st2), a platform for event-driven automation.

Disclaimer: I work for StackStorm, but the platform itself is fully open source under Apache 2.0.