### PR TITLE
Fixed URL

### DIFF
--- a/data/tools/condep.json
+++ b/data/tools/condep.json
@@ -11,6 +11,6 @@
             "config-mgmt",
             "net"
         ],
-        "url": "http://www.con-dep.net"
+        "url": "http://www.condep.io/"
     }
 ]


### PR DESCRIPTION

Per this news http://www.condep.io/info/2014/12/31/New-Domain-Name.html
switched to http://www.condep.io/