### PR TITLE
Added the Assimilation System Management Suite.

### DIFF
--- a/data/tools/assimilation.json
+++ b/data/tools/assimilation.json
@@ -1,0 +1,23 @@
+[
+  {
+    "slug": "assimilation",
+    "name": "Assimilation System Management Suite",
+    "description": "The Assimilation Suite discovers systems, services, network connections, configuration and dependencies, IP and MAC addresses. This all goes into a continually updated graph-based configuration management database (CMDB).  This is then compared and scored against best practices, services and servers are monitored - all with near-zero configuration - in a way that scales to hundreds of thousands of servers.\nIt also provides visualization tools, APIs for sending alerts to humans and other systems, and a variety of canned reports (queries) to aid in securing and managing systems, hooking into ChatOps, and creating plans for triaging your security issues",
+    "url": "http://AssimilationSystems.com/",
+    "tags": [
+      "linux",
+      "open-source",
+      "commercial",
+      "C",
+      "shell",
+      "python",
+      "config",
+      "CMDB",
+      "service-discovery",
+      "monitoring",
+      "visualization",
+      "security",
+      "hardening"
+    ]
+  }
+]


### PR DESCRIPTION
I added the category CMDB, which you don't yet have. It's really separate from the other categories. Although it's _related_ to configuration management, it's about providing an informational database for querying, not about pushing out configuration.

It's related to inventory management and so on. In my case, the database is all automatically maintained, and the orientation is less about inventory as it is about configuration - although we discover plenty of inventory-related stuff too.

One other use for it is to audit "what is" against what some other tool (ansible, chef, saltstack, puppet for example) says "what should be".

In addition, it can inform you via best practice audits of where things could be improved.
