### PR TITLE
Url Correction - Ansible and Cobbler

### DIFF
--- a/data/tools/ansible.json
+++ b/data/tools/ansible.json
@@ -11,6 +11,6 @@
       "orchestration",
       "python"
     ],
-    "url": "http://www.ansibleworks.com"
+    "url": "https://www.ansible.com/"
   }
 ]

--- a/data/tools/cobbler.json
+++ b/data/tools/cobbler.json
@@ -10,6 +10,6 @@
       "provisioning",
       "orchestration"
     ],
-    "url": "http://www.cobblerd.org/"
+    "url": "http://cobbler.github.io/"
   }
 ]


### PR DESCRIPTION
I am correcting 2 urls.

Correction Ansible url.
Old url http://www.ansibleworks.com/ - Not work.
New Ansible url https://www.ansible.com/

Correcting the url Cobbler.
Old url: http://cobbler.github.io/ - Not work.
New url: http://cobbler.github.io/ - OK