### PR TITLE
Netflix Vizceral : Tool for Traffic visualization

### DIFF
--- a/data/tools/vizceral.json
+++ b/data/tools/vizceral.json
@@ -1,0 +1,14 @@
+[
+  {
+    "slug": "Vizceral",
+    "name": "Vizceral",
+    "description": "Netflix Vizceral is a component for displaying traffic data on a webgl canvas. If a graph of nodes and edges with data about traffic volume is provided, it will render a traffic graph animating the connection volume between nodes. This component can take multiple traffic graphs and will generate a 'global' graph showing all incoming traffic into each of the 'regions', with support for cross-region traffic. There are three levels of information, global, regional, and service-level, with clicking or double-clicking on a node bringing you one level deeper.",
+    "tags": [
+      "linux",
+      "open-source",
+      "monitoring",
+      "visualization"
+    ],
+    "url": "https://github.com/netflix/vizceral"
+  }
+]


### PR DESCRIPTION
Netflix Vizceral is a component for displaying traffic data on a webgl canvas. If a graph of nodes and edges with data about traffic volume is provided, it will render a traffic graph animating the connection volume between nodes. This component can take multiple traffic graphs and will generate a 'global' graph showing all incoming traffic into each of the 'regions', with support for cross-region traffic. There are three levels of information, global, regional, and service-level, with clicking or double-clicking on a node bringing you one level deeper.