### PR TITLE
Remove Windows from Supervisor tags

### DIFF
--- a/data/tools/supervisord.json
+++ b/data/tools/supervisord.json
@@ -5,7 +5,6 @@
     "description": "Supervisor can manage application processes. It can start and stop a group of processes, restart processes if any of them terminate (keep-alive), start multiple instances of the same process (process pooling), automatically manage PID files, and much more! Very useful if you need to manage multiple processes for your application.",
     "tags": [
       "linux",
-      "windows",
       "osx",
       "open-source",
       "process-mgmt",


### PR DESCRIPTION
The [Supervisor documentation](http://supervisord.org/introduction.html#platform-requirements) states:

> Supervisor will not run at all under any version of Windows

So I've removed Windows from the tags.