### PR TITLE
Include Fabric8

### DIFF
--- a/data/tools/fabric8.json
+++ b/data/tools/fabric8.json
@@ -1,0 +1,18 @@
+[
+  {
+    "slug": "fabric8",
+    "name": "Fabric8",
+    "description": "fabric8 is an end to end development platform spanning ideation to production for the creation of cloud native applications and microservices",
+    "url": "https://fabric8.io/",
+    "tags": [
+      "linux",
+      "windows",
+      "osx",
+      "open-source",
+      "free",
+      "cloud-paas",
+      "virt",
+      "go"
+    ]
+  }
+]


### PR DESCRIPTION
Include Fabric8 - fabric8 is an opinionated open source Microservices Platform based on Docker, Kubernetes and Jenkins

fabric8 makes it easy to create Microservices, build, test and deploy them via Continuous Delivery pipelines then run and manage them with Continuous Improvement and ChatOps

URL: https://fabric8.io/
