### PR TITLE
Add Bolt and update Puppet url

### DIFF
--- a/data/tools/bolt.json
+++ b/data/tools/bolt.json
@@ -1,0 +1,16 @@
+[
+  {
+    "slug": "bolt",
+    "name": "Bolt",
+    "description": "Bolt is an open source commandline tool for executing commands, scripts, and orchestrated workflows on remote systems using SSH and WinRM",
+    "tags": [
+      "linux",
+      "open-source",
+      "provisioning",
+      "config-mgmt",
+      "orchestration",
+      "ruby"
+    ],
+    "url": "https://bolt.guide"
+  }
+]

--- a/data/tools/puppet.json
+++ b/data/tools/puppet.json
@@ -11,6 +11,6 @@
       "config-mgmt",
       "ruby"
     ],
-    "url": "http://www.puppetlabs.com"
+    "url": "https://www.puppet.com"
   }
 ]


### PR DESCRIPTION
This adds an open source tool, Bolt, which enables ad-hoc remote
configuration management across multiple systems. It also updates the
Puppet url to the new(ish) url.