### PR TITLE
Update Vagrantfile to use CentOS7 and update npm packages

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -1,8 +1,5 @@
-# Vagrantfile API/syntax version. Don't touch unless you know what you're doing!
-VAGRANTFILE_API_VERSION = "2"
-
-Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
-  config.vm.box = "ubuntu/trusty64"
+Vagrant.configure("2") do |config|
+  config.vm.box = "centos/7"
   config.vm.network "forwarded_port", guest: 3000, host: 3000
 
   if Vagrant.has_plugin?('vagrant-cachier')
@@ -12,9 +9,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
   end
 
   config.vm.provision :shell, privileged: true, inline: <<-SCRIPT
+    yum update
+    yum install -y curl vim build-essential git
     echo "Installing necessary packages..."
-    curl -sSL https://deb.nodesource.com/setup | sudo bash -
-    apt-get install -y build-essential git nodejs
+    curl -sSL https://rpm.nodesource.com/setup_13.x | sudo bash -
+    yum install -y nodejs
     npm install -g grunt-cli
 
     echo 'Fix potential git problem with Bower set up and connecting to github'

--- a/package.json
+++ b/package.json
@@ -8,25 +8,25 @@
     "heroku-postbuild": "grunt build"
   },
   "engines": {
-    "node": "4.x"
+    "node": "13.x"
   },
   "dependencies": {
-    "compression": "^1.6.0",
-    "connect-redirecthost": "^2.0.0",
+    "compression": "^1.7.4",
+    "connect-redirecthost": "^3.0.0",
     "ejs": "^2.3.4",
-    "errorhandler": "^1.4.2",
-    "express": "^4.13.3",
-    "grunt": "^0.4.5",
-    "grunt-bower-task": "^0.4.0",
-    "grunt-cli": "^0.1.13",
-    "grunt-contrib-jshint": "^0.11.0",
-    "grunt-contrib-watch": "^0.6.1",
-    "grunt-express-server": "^0.5.1",
-    "grunt-sass": "^1.1.0",
-    "load-grunt-tasks": "^3.3.0",
-    "morgan": "^1.6.1",
+    "errorhandler": "^1.5.1",
+    "express": "^4.17.1",
+    "grunt": "^1.0.4",
+    "grunt-bower-task": "^0.5.0",
+    "grunt-cli": "^1.3.2",
+    "grunt-contrib-jshint": "^2.1.0",
+    "grunt-contrib-watch": "^1.1.0",
+    "grunt-express-server": "^0.5.4",
+    "grunt-sass": "^3.1.0",
+    "load-grunt-tasks": "^5.1.0",
+    "morgan": "^1.9.1",
     "static-asset": "^0.6.0",
-    "underscore": "^1.8.3",
-    "walk": "^2.3.9"
+    "underscore": "^1.9.2",
+    "walk": "^2.3.14"
   }
 }


### PR DESCRIPTION
This may likely be breakable changes to the current infra. Vagrantfile is currently using Trust, which is EOL. New Vagrantfile is using CentOS7 with the new version of NodeJS. NPM packages have also been updated to reflect this. 