### PR TITLE
Update build status link and image

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ and frameworks.
 
 ## Deployment Status
 
-[![Build Status](https://snap-ci.com/devopsbookmarks/devopsbookmarks.com/branch/master/build_image)](https://snap-ci.com/devopsbookmarks/devopsbookmarks.com/branch/master)
+[![Build Status](https://travis-ci.org/devopsbookmarks/devopsbookmarks.com.svg?branch=master)](https://travis-ci.org/devopsbookmarks/devopsbookmarks.com)
 
 ## Contributing
 


### PR DESCRIPTION
Image is currently broken and going to a bad link. Fix link to go to travis-ci.