### PR TITLE
Update concourse.json

### DIFF
--- a/data/tools/concourse.json
+++ b/data/tools/concourse.json
@@ -3,7 +3,7 @@
     "slug": "concourse",
     "name": "Concourse",
     "description": "Concourse is a CI system composed of simple tools and ideas. It can express entire pipelines, integrating with arbitrary resources, or it can be used to execute one-off tasks, either locally or in another CI system.",
-    "url": "http://concourse.ci/",
+    "url": "https://concourse-ci.org/",
     "tags": [
       "linux",
       "open-source",


### PR DESCRIPTION
Update URL of Concourse CI
The new URL is https://concourse-ci.org/ now