### PR TITLE
Fix url for mgmt

### DIFF
--- a/data/tools/mgmt.json
+++ b/data/tools/mgmt.json
@@ -3,7 +3,7 @@
     "slug": "mgmt",
     "name": "mgmt",
     "description": "The mgmt tool is a distributed, event driven, config management tool, that supports parallel execution, and librarification to be used as the management foundation in and for, new and existing software.",
-    "url": "https://github.com/purpleidea/mgmt/blob/master/DOCUMENTATION.md",
+    "url": "https://github.com/purpleidea/mgmt/blob/master/docs/documentation.md",
     "tags": [
       "linux",
       "osx",


### PR DESCRIPTION
The URL has changed and documentation.md has been moved to docs/.